### PR TITLE
Don’t exit with error on 404s during SSG

### DIFF
--- a/modules/generate.js
+++ b/modules/generate.js
@@ -4,12 +4,6 @@
 import { isGenerating } from '../helpers/env'
 export default function() {
 
-	// Exit immediately when a route fails
-	this.nuxt.hook('generate:routeFailed', ({ errors }) => {
-		errors.forEach(error => console.error(error))
-		process.exit(1)
-	})
-
 	// Support falling back to a resolvable file on Netlify if a route didn't
 	// exist when build was run.  We only want this to run when _not_ using
 	// generate so we return true 404s.
@@ -25,4 +19,34 @@ export default function() {
 
 	// Sub folders, set to false to remove the trailing slashes
 	this.options.generate.subFolders = false
+
+	// Immediately exit for route level errors, like Axios errors.  The errors
+	// array looks like:
+	//	{
+	//		type: 'unhandled',
+	//		route: '/products/cam-wall-mounting-kit/19731607617609',
+	//		error: // An actual exception object
+	//	}
+	this.nuxt.hook('generate:routeFailed', ({ errors }) => {
+		errors.forEach(error => console.error(error))
+		process.exit(1)
+	})
+
+	// Abort SSG if any of the errors weren't 404s with an "ENOENT" error. The
+	// 404 errors don't fire the generate:routeFailed hook for some reason. The
+	// errors array contains objects that look like:
+	//	{
+	//		type: 'handled',
+	//		route: '/products/play-time-fabric-sock',
+	//		error: {
+	//			statusCode: 404,
+	//			message: 'Page not found'
+	//		}
+	//	}
+	this.nuxt.hook('generate:done', (generator, errors) => {
+		if (errors.filter((error) => {
+			return error?.error?.statusCode != 404
+		}).length) process.exit(2)
+	})
+
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"dev": "nuxt dev demo",
 		"build": "nuxt build demo",
 		"start": "nuxt start demo",
-		"generate": "nuxt generate --fail-on-error --target=static demo"
+		"generate": "nuxt generate --target=static demo"
 	},
 	"dependencies": {
 		"@bkwld/credits": "^0.3.0",


### PR DESCRIPTION
These routes still get added to nuxt/sitemap, which isn’t ideal.  But I think that’s less significant, it’ll just so the site 404 if someone tries to visit the page