### PR TITLE
Always require PWA module

### DIFF
--- a/modules/pwa.js
+++ b/modules/pwa.js
@@ -36,8 +36,6 @@ export default function() {
 		}
 	}})
 
-	// Add the PWA module when not running dev mode. During dev mode, the
-	// manifest.json was emitting 404 responses.  These only went away when
-	// fully disabling the meta and manifest properites.
-	if (!isDev) requireOnce(this, '@nuxtjs/pwa')
+	// Add the PWA module
+	requireOnce(this, '@nuxtjs/pwa')
 }


### PR DESCRIPTION
I don’t really recall what these 404s were that I was concerned about.  But we want PWA to still be added during dev so that the viewport meta tag is added.

See https://app.asana.com/0/1200777795870740/1202888083494042/f